### PR TITLE
add sensors for JumpToken balances

### DIFF
--- a/custom_components/honeygain/__init__.py
+++ b/custom_components/honeygain/__init__.py
@@ -61,6 +61,8 @@ class HoneygainData:
         self.balances: dict = {}
         self.stats: dict = {}
         self.today_stats: dict = {}
+        self.stats_jt: dict = {}
+        self.today_stats_jt: dict = {}
 
     @Throttle(UPDATE_INTERVAL)
     def update(self) -> None:
@@ -70,6 +72,9 @@ class HoneygainData:
             self.balances = self.honeygain.balances()
             self.stats = self.honeygain.stats()
             self.today_stats = self.honeygain.stats_today()
+            self.stats_jt = self.honeygain.stats_jt()
+            self.today_stats_jt = self.honeygain.stats_today_jt()
+
         except CannotConnect:
             LOGGER.warning("Failed to connect to Honeygain for update")
         except InvalidAuth:

--- a/custom_components/honeygain/sensor.py
+++ b/custom_components/honeygain/sensor.py
@@ -60,6 +60,13 @@ HONEYGAIN_SENSORS: list[SensorValueEntityDescription] = [
         value=lambda x: x.today_stats.get("gathering").get("credits"),
     ),
     SensorValueEntityDescription(
+        key="today_credits_jt",
+        name="Today's JMPT credits",
+        icon="mdi:calendar-today",
+        state_class=SensorStateClass.TOTAL,
+        value=lambda x: x.today_stats_jt.get("gathering").get("credits"),
+    ),
+    SensorValueEntityDescription(
         key="today_bandwidth",
         name="Today's shared bandwidth",
         icon="mdi:upload",
@@ -75,11 +82,25 @@ HONEYGAIN_SENSORS: list[SensorValueEntityDescription] = [
         value=lambda x: x.today_stats.get("referral").get("credits"),
     ),
     SensorValueEntityDescription(
+        key="today_referral_credits_jt",
+        name="Today's JMPT referral credits",
+        icon="mdi:account-multiple",
+        state_class=SensorStateClass.TOTAL,
+        value=lambda x: x.today_stats_jt.get("referral").get("credits"),
+    ),
+    SensorValueEntityDescription(
         key="today_lucky_pot_credits",
         name="Today's Lucky Pot credits",
         icon="mdi:gift-open",
         state_class=SensorStateClass.TOTAL,
         value=lambda x: x.today_stats.get("winning").get("credits"),
+    ),
+    SensorValueEntityDescription(
+        key="today_lucky_pot_credits_jt",
+        name="Today's JMPT Lucky Pot credits",
+        icon="mdi:gift-open",
+        state_class=SensorStateClass.TOTAL,
+        value=lambda x: x.today_stats_jt.get("winning").get("credits"),
     ),
 ]
 

--- a/custom_components/honeygain/sensor.py
+++ b/custom_components/honeygain/sensor.py
@@ -67,6 +67,20 @@ HONEYGAIN_SENSORS: list[SensorValueEntityDescription] = [
         value=lambda x: x.today_stats_jt.get("gathering").get("credits"),
     ),
     SensorValueEntityDescription(
+        key="today_total_credits",
+        name="Today's total credits",
+        icon="mdi:calendar-today",
+        state_class=SensorStateClass.TOTAL,
+        value=lambda x: x.today_stats.get("total").get("credits"),
+    ),
+    SensorValueEntityDescription(
+        key="today_total_credits_jt",
+        name="Today's total JMPT credits",
+        icon="mdi:calendar-today",
+        state_class=SensorStateClass.TOTAL,
+        value=lambda x: x.today_stats_jt.get("total").get("credits"),
+    ),
+    SensorValueEntityDescription(
         key="today_bandwidth",
         name="Today's shared bandwidth",
         icon="mdi:upload",


### PR DESCRIPTION
As per [https://github.com/SplinterHead/ha-honeygain/issues/13](url), I have added sensors that pick up on JMPT payments adding:

- Today's JMPT credits
- Today's JMPT Lucky Pot credits
- Today's JMPT referral credits

To the detected sensors in Home Assistant